### PR TITLE
- Added code to log and gracefully skip missing files

### DIFF
--- a/classes/datatypes/ezbinaryfile/plugins/ezmultiparser.php
+++ b/classes/datatypes/ezbinaryfile/plugins/ezmultiparser.php
@@ -61,6 +61,12 @@ class eZMultiParser
 
     function parseFile( $fileName )
     {
+        if( !$fileName )
+        {
+            eZDebug::writeError( "eztika cannot find the file $fileName; skipping", 'eztika class eZMultiParser' );
+            return false;
+        }
+
         $originalFileSize = filesize( $fileName );
         $this->writeEzTikaLog( '[START] eZMultiParser for File: '. round( $originalFileSize/1024, 2 ) .' KByte '. $fileName );
 


### PR DESCRIPTION
We found eztika was stalling if a file to be indexed was missing.  This update logs the event and allows the index to complete.  @peterkeung
